### PR TITLE
Add PrimeCars chat widget integration

### DIFF
--- a/css/chat-widget.css
+++ b/css/chat-widget.css
@@ -1,0 +1,246 @@
+/* PrimeCars Chat Widget Styles */
+.pc-chat-bubble {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #0f81d5 0%, #2dd1c6 100%);
+  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 24px;
+  cursor: pointer;
+  z-index: 1000;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pc-chat-bubble:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.25);
+}
+
+.pc-chat-modal {
+  position: fixed;
+  right: 24px;
+  bottom: 96px;
+  width: 360px;
+  max-height: 520px;
+  background: #0b1523;
+  color: #f0f4f9;
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 1000;
+}
+
+.pc-chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.pc-chat-header h4 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+}
+
+.pc-chat-header small {
+  display: block;
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.pc-chat-close {
+  background: none;
+  border: none;
+  color: #f0f4f9;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.pc-chat-body {
+  padding: 12px 12px 0;
+  flex: 1;
+  overflow-y: auto;
+  background: radial-gradient(circle at top right, rgba(45, 209, 198, 0.15), transparent 40%),
+    radial-gradient(circle at bottom left, rgba(15, 129, 213, 0.1), transparent 35%);
+}
+
+.pc-chat-message {
+  display: flex;
+  margin-bottom: 12px;
+  gap: 8px;
+}
+
+.pc-chat-message.user {
+  flex-direction: row-reverse;
+}
+
+.pc-chat-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 14px;
+  background: rgba(45, 209, 198, 0.2);
+  border: 1px solid rgba(45, 209, 198, 0.4);
+}
+
+.pc-chat-avatar.user {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.pc-chat-bubble-msg {
+  max-width: 240px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  white-space: pre-wrap;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.pc-chat-message.user .pc-chat-bubble-msg {
+  background: #0f81d5;
+  color: #fff;
+  border-color: #0f81d5;
+  border-bottom-right-radius: 4px;
+}
+
+.pc-chat-message.agent .pc-chat-bubble-msg {
+  border-bottom-left-radius: 4px;
+}
+
+.pc-chat-typing {
+  display: inline-block;
+  min-width: 72px;
+}
+
+.pc-chat-typing span {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 4px;
+  background: #2dd1c6;
+  border-radius: 50%;
+  animation: pcTyping 1s infinite ease-in-out;
+}
+
+.pc-chat-typing span:nth-child(2) {
+  animation-delay: 0.12s;
+}
+
+.pc-chat-typing span:nth-child(3) {
+  animation-delay: 0.24s;
+}
+
+@keyframes pcTyping {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.6);
+    opacity: 0.4;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.pc-chat-footer {
+  padding: 10px 12px 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(11, 21, 35, 0.92);
+}
+
+.pc-chat-input-wrapper {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.pc-chat-input-wrapper textarea {
+  flex: 1;
+  resize: none;
+  min-height: 48px;
+  max-height: 120px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  color: #f0f4f9;
+  padding: 10px 12px;
+  font-size: 14px;
+  outline: none;
+}
+
+.pc-chat-input-wrapper textarea:focus {
+  border-color: rgba(45, 209, 198, 0.6);
+}
+
+.pc-chat-send-btn {
+  background: linear-gradient(135deg, #0f81d5 0%, #2dd1c6 100%);
+  border: none;
+  color: #0b1523;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.pc-chat-send-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.pc-chat-send-btn:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.pc-chat-hint {
+  font-size: 11px;
+  opacity: 0.75;
+  margin-top: 6px;
+}
+
+.pc-chat-error {
+  color: #ff8c9f;
+  font-size: 12px;
+  margin: 6px 0;
+}
+
+.pc-chat-session {
+  font-size: 10px;
+  opacity: 0.65;
+  letter-spacing: 0.3px;
+}
+
+@media (max-width: 600px) {
+  .pc-chat-modal {
+    right: 12px;
+    bottom: 88px;
+    width: calc(100% - 24px);
+  }
+
+  .pc-chat-bubble {
+    right: 16px;
+    bottom: 16px;
+  }
+}

--- a/docs/FRONTEND_CHAT.md
+++ b/docs/FRONTEND_CHAT.md
@@ -1,0 +1,51 @@
+# PrimeCars Frontend Chat Widget
+
+This guide explains how the PrimeCars landing page connects to the customer-support agent exposed at `/api/v1/agent/chat` and `/api/v1/agent/chat-stateless`.
+
+## Overview
+- The widget is rendered by `js/chat-widget.js` and styled by `css/chat-widget.css`.
+- It loads React and ReactDOM from their public UMD builds and mounts into a dynamic `<div id="pc-chat-widget-root">` at the end of `index.html`.
+- State is persisted in `sessionStorage` so the conversation and `session_id` survive page reloads during the same browser session.
+- The UI shows a typing indicator, handles network errors with a friendly fallback, and **never** sends internal keys.
+
+## Configuration
+- `VITE_API_BASE_URL`: optional base URL for the backend (e.g., `https://primecars.example.com`). If omitted, the widget calls the same-origin `/api/v1/agent/chat` endpoint.
+- `VITE_CHAT_USE_STATELESS`: set to `true` to call `/api/v1/agent/chat-stateless` instead of the stateful endpoint.
+
+Expose these values via the `window.ENV` object before loading `chat-widget.js`, for example:
+
+```html
+<script>
+  window.ENV = {
+    VITE_API_BASE_URL: 'https://primecars.example.com',
+    VITE_CHAT_USE_STATELESS: 'false'
+  };
+</script>
+```
+
+## Payload contract
+User messages send:
+
+```json
+{
+  "user_id": "web-user",
+  "session_id": "<existing or empty>",
+  "message": "<texto>"
+}
+```
+
+Responses expected:
+
+```json
+{
+  "session_id": "...",
+  "response": "..."
+}
+```
+
+The widget preserves the `session_id` returned by the backend (unless stateless mode is enabled) and appends each reply to the local history.
+
+## Error handling and fallbacks
+- Network failures or empty responses display a friendly fallback message in the chat and keep the conversation open for retry.
+- The widget shows a typing indicator while waiting for the backend response.
+- No `X-Internal-Key` is sent; only the public endpoint is used.

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="css/owl.carousel.css" type="text/css">
     <link rel="stylesheet" href="css/magnific-popup.css" type="text/css">
     <link rel="stylesheet" href="css/main.css" type="text/css">
+    <link rel="stylesheet" href="css/chat-widget.css" type="text/css">
   </head>
 
   <body>
@@ -1283,5 +1284,8 @@
 
     <script src="js/validator.js"></script>
     <script src="js/main.js"></script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="js/chat-widget.js"></script>
   </body>
 </html>

--- a/js/chat-widget.js
+++ b/js/chat-widget.js
@@ -1,0 +1,218 @@
+(function () {
+  const { useEffect, useMemo, useRef, useState } = React;
+
+  const STORAGE_KEYS = {
+    session: 'primecars_chat_session_id',
+    messages: 'primecars_chat_messages',
+  };
+
+  const FALLBACK_MESSAGE =
+    'Lo siento, no he podido recuperar la respuesta ahora mismo. Por favor, inténtalo de nuevo o comparte más detalles.';
+
+  function normalizeBaseUrl(url) {
+    if (!url) return '';
+    return url.endsWith('/') ? url.slice(0, -1) : url;
+  }
+
+  function loadFromStorage(key, fallback) {
+    try {
+      const raw = window.sessionStorage.getItem(key);
+      return raw ? JSON.parse(raw) : fallback;
+    } catch (error) {
+      return fallback;
+    }
+  }
+
+  function saveToStorage(key, value) {
+    try {
+      window.sessionStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      /* ignore */
+    }
+  }
+
+  function ChatWidget() {
+    const [isOpen, setIsOpen] = useState(false);
+    const [sessionId, setSessionId] = useState(() => loadFromStorage(STORAGE_KEYS.session, ''));
+    const [messages, setMessages] = useState(() =>
+      loadFromStorage(STORAGE_KEYS.messages, [
+        {
+          id: 'intro',
+          role: 'agent',
+          text: '¡Hola! Soy el asistente de PrimeCars. Pregúntame por ofertas, reservas o información de la plataforma.',
+        },
+      ]),
+    );
+    const [inputValue, setInputValue] = useState('');
+    const [isSending, setIsSending] = useState(false);
+    const [error, setError] = useState('');
+
+    const messagesEndRef = useRef(null);
+
+    const apiBaseUrl = useMemo(
+      () => normalizeBaseUrl(window.ENV?.VITE_API_BASE_URL || ''),
+      [],
+    );
+    const useStateless = useMemo(() => (window.ENV?.VITE_CHAT_USE_STATELESS || '').toString() === 'true', []);
+
+    const endpoint = useMemo(() => {
+      const path = useStateless ? '/api/v1/agent/chat-stateless' : '/api/v1/agent/chat';
+      return `${apiBaseUrl}${path}` || path;
+    }, [apiBaseUrl, useStateless]);
+
+    useEffect(() => {
+      saveToStorage(STORAGE_KEYS.session, sessionId || '');
+    }, [sessionId]);
+
+    useEffect(() => {
+      saveToStorage(STORAGE_KEYS.messages, messages);
+    }, [messages]);
+
+    useEffect(() => {
+      if (messagesEndRef.current) {
+        messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    }, [messages, isOpen]);
+
+    const pushMessage = (message) => setMessages((prev) => [...prev, message]);
+
+    const replaceTypingWith = (newMessage) => {
+      setMessages((prev) => {
+        const filtered = prev.filter((msg) => msg.status !== 'typing');
+        return [...filtered, newMessage];
+      });
+    };
+
+    const handleSend = async () => {
+      const content = inputValue.trim();
+      if (!content || isSending) return;
+
+      setError('');
+      setIsSending(true);
+      setInputValue('');
+
+      const userMessage = { id: `user-${Date.now()}`, role: 'user', text: content };
+      pushMessage(userMessage);
+      pushMessage({ id: `typing-${Date.now()}`, role: 'agent', text: 'Escribiendo…', status: 'typing' });
+
+      try {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            user_id: 'web-user',
+            session_id: useStateless ? '' : sessionId || '',
+            message: content,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error('No se pudo contactar con el agente.');
+        }
+
+        const data = await response.json();
+        const reply = (data?.response || '').trim();
+        const newSessionId = data?.session_id || '';
+
+        if (!useStateless && newSessionId) {
+          setSessionId(newSessionId);
+        }
+
+        if (reply) {
+          replaceTypingWith({ id: `agent-${Date.now()}`, role: 'agent', text: reply });
+        } else {
+          replaceTypingWith({ id: `agent-${Date.now()}`, role: 'agent', text: FALLBACK_MESSAGE, status: 'fallback' });
+        }
+      } catch (err) {
+        setError(err.message || 'Se produjo un error al enviar tu mensaje.');
+        replaceTypingWith({ id: `error-${Date.now()}`, role: 'agent', text: FALLBACK_MESSAGE, status: 'error' });
+      } finally {
+        setIsSending(false);
+      }
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        handleSend();
+      }
+    };
+
+    return (
+      React.createElement(React.Fragment, null,
+        React.createElement('div', {
+          className: 'pc-chat-bubble',
+          role: 'button',
+          'aria-label': 'Abrir chat PrimeCars',
+          onClick: () => setIsOpen((open) => !open),
+        }, '💬'),
+        isOpen && React.createElement('div', { className: 'pc-chat-modal' },
+          React.createElement('div', { className: 'pc-chat-header' },
+            React.createElement('div', null,
+              React.createElement('h4', null, 'Asistente PrimeCars'),
+              React.createElement('small', null, useStateless ? 'Modo sin estado' : 'Sesión activa para tu conversación'),
+              !useStateless && sessionId && React.createElement('span', { className: 'pc-chat-session' }, `ID: ${sessionId}`),
+            ),
+            React.createElement('button', { className: 'pc-chat-close', onClick: () => setIsOpen(false), 'aria-label': 'Cerrar chat' }, '×'),
+          ),
+          React.createElement('div', { className: 'pc-chat-body' },
+            messages.map((msg) => (
+              React.createElement('div', { key: msg.id, className: `pc-chat-message ${msg.role}` },
+                React.createElement('div', { className: `pc-chat-avatar ${msg.role}` }, msg.role === 'agent' ? 'PC' : 'Tú'),
+                React.createElement('div', { className: 'pc-chat-bubble-msg' },
+                  msg.status === 'typing'
+                    ? React.createElement('div', { className: 'pc-chat-typing', 'aria-label': 'Escribiendo' },
+                        React.createElement('span', null),
+                        React.createElement('span', null),
+                        React.createElement('span', null),
+                      )
+                    : msg.text,
+                ),
+              )
+            )),
+            React.createElement('div', { ref: messagesEndRef }),
+          ),
+          React.createElement('div', { className: 'pc-chat-footer' },
+            error && React.createElement('div', { className: 'pc-chat-error' }, error),
+            React.createElement('div', { className: 'pc-chat-input-wrapper' },
+              React.createElement('textarea', {
+                value: inputValue,
+                placeholder: 'Escribe tu mensaje...',
+                onChange: (e) => setInputValue(e.target.value),
+                onKeyDown: handleKeyDown,
+                disabled: isSending,
+              }),
+              React.createElement('button', {
+                className: 'pc-chat-send-btn',
+                onClick: handleSend,
+                disabled: isSending || !inputValue.trim(),
+              }, isSending ? 'Enviando…' : 'Enviar'),
+            ),
+            React.createElement('div', { className: 'pc-chat-hint' }, 'Sin claves internas: la integración usa únicamente el endpoint público del agente.'),
+          ),
+        ),
+      )
+    );
+  }
+
+  function renderWidget() {
+    const rootElementId = 'pc-chat-widget-root';
+    let rootElement = document.getElementById(rootElementId);
+    if (!rootElement) {
+      rootElement = document.createElement('div');
+      rootElement.id = rootElementId;
+      document.body.appendChild(rootElement);
+    }
+
+    const root = ReactDOM.createRoot(rootElement);
+    root.render(React.createElement(ChatWidget));
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    renderWidget();
+  } else {
+    document.addEventListener('DOMContentLoaded', renderWidget);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a React-powered chat widget to the landing page that calls the PrimeCars agent endpoints with session persistence and typing feedback
- style the floating chat bubble and modal to match the brand and handle errors/fallback responses gracefully
- document configuration and usage for the frontend chat integration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931eb0ed1908324acd30fe348b6f8b0)